### PR TITLE
Add ship.rb and ship_spec.rb files

### DIFF
--- a/lib/ship.rb
+++ b/lib/ship.rb
@@ -1,0 +1,1 @@
+#Created ship.rb file

--- a/spec/ship_spec.rb
+++ b/spec/ship_spec.rb
@@ -1,0 +1,1 @@
+#Created ship_spec.rb file


### PR DESCRIPTION
Forgot to create a lib directory that contained a ship.rb file and a spec directory that contained a ship_spec.rb. Fixed and created both directories and the files contained within them.